### PR TITLE
Add Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
 'use strict';
-module.exports = function () {
-	return process.getuid && process.getuid() === 0;
+
+var os = require('os');
+
+module.exports = function (callback) {
+	if (os.platform() === 'win32') {
+		var wincmd = require('node-windows');
+		wincmd.isAdminUser(callback);
+	} else {
+		callback(process.getuid && process.getuid() === 0);
+	}
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,11 @@
     "process",
     "posix"
   ],
+  "optionalDependencies": {
+    "node-windows": "^0.1.7"
+  },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "proxyquire": "^1.4.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # is-root [![Build Status](https://travis-ci.org/sindresorhus/is-root.svg?branch=master)](https://travis-ci.org/sindresorhus/is-root)
 
-> Check if the process is running as root user, eg. started with `sudo`.
+> Check if the process is running as root user, eg. started with `sudo`, or as the Administrator user in the case of Windows.
 
 
 ## Install
@@ -20,8 +20,9 @@ $ sudo node index.js
 // index.js
 var isRoot = require('is-root');
 
-isRoot();
-//=> true
+isRoot(function (result) {
+	// result == true
+});
 ```
 
 


### PR DESCRIPTION
Check that the current user is the administrator user.

It makes use of https://github.com/coreybutler/node-windows, which sets the `os` property to `win32`, therefore `npm install --force` is needed to run the tests in UNIX based operating systems (configurable in Travis CI somehow I guess) (at runtime, the dependency is only loaded if `os.platform() === 'win32'`).

Addresses https://github.com/sindresorhus/is-root/issues/1 and https://github.com/sindresorhus/is-root/issues/2.
